### PR TITLE
remove geolocate in Depredadores

### DIFF
--- a/src/views/wp/Depredadores.vue
+++ b/src/views/wp/Depredadores.vue
@@ -760,7 +760,7 @@ export default {
         this.$analytics.logEvent('wp-depredadores', {
             path,
         })
-        this.geolocate()
+        // this.geolocate()
     },
 }
 </script>


### PR DESCRIPTION
Se elimino el geolocate() en mounted para no solicitar al usuario su ubicacion.